### PR TITLE
C++ accommodate include local imports

### DIFF
--- a/lua/import/filetypes.lua
+++ b/lua/import/filetypes.lua
@@ -15,7 +15,7 @@ local filetypes = {
     extensions = { "js", "ts" },
   },
   {
-    regex = [[^(?:#include <.*>)]],
+    regex = [[^(?:#include [\"<].*[\">])\s*]],
     filetypes = { "c", "cpp" },
     extensions = { "h", "c", "cpp" },
   },


### PR DESCRIPTION
This should also catch local imports aka. `#include "local_stuffZ"`, and should maybe also match when there are multiple spaces at the end of the line.