### PR TITLE
add javascriptreact filetype, remove invalid react filetype

### DIFF
--- a/lua/import/filetypes.lua
+++ b/lua/import/filetypes.lua
@@ -11,8 +11,8 @@ local filetypes = {
   },
   {
     regex = [[^(?:import(?:[\"'\s]*([\w*{}\n, ]+)from\s*)?[\"'\s](.*?)[\"'\s].*)]],
-    filetypes = { "typescript", "typescriptreact", "javascript", "react" },
-    extensions = { "js", "ts" },
+    filetypes = { "javascript", "javascriptreact", "typescript", "typescriptreact"},
+    extensions = { "js", "jsx", "ts", "tsx" },
   },
   {
     regex = [[^(?:#include <.*>)]],


### PR DESCRIPTION
### Issue
I am getting an error message when running `:Telescope import` while viewing a `javascriptreact` filetype file:

![image](https://github.com/piersolenski/telescope-import.nvim/assets/62859552/8a27422d-7e76-4513-a9e5-99d1e26402d9)

### Cause
There is no `javascriptreact` filetype support.

### Solution
This adds support for `javascriptreact` filetype files, and removes the invalid `react` filetype.

Output from `:set filetype?` in a `.jsx` buffer:

![image](https://github.com/piersolenski/telescope-import.nvim/assets/62859552/d1ec13fb-24f0-48f6-80ef-a3d5b402cead)
