### PR TITLE
docs: rename "requires" to "dependencies"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Install [ripgrep](https://github.com/BurntSushi/ripgrep).
 -- Lazy
 {
   'piersolenski/telescope-import.nvim',
-  requires = 'nvim-telescope/telescope.nvim'
+  dependencies = 'nvim-telescope/telescope.nvim'
   config = function()
     require("telescope").load_extension("import")
   end

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://github.com/piersolenski/telescope-import.nvim/assets/1285419/014753e3-ea
 - Bash
 - C++
 - Java
-- JavaScript 
+- JavaScript
 - Typescript
 - Lua
 - PHP
@@ -22,7 +22,7 @@ https://github.com/piersolenski/telescope-import.nvim/assets/1285419/014753e3-ea
 ## 🔩 Installation
 
 Install [ripgrep](https://github.com/BurntSushi/ripgrep).
- 
+
 ```lua
 -- Lazy
 {
@@ -32,6 +32,7 @@ Install [ripgrep](https://github.com/BurntSushi/ripgrep).
     require("telescope").load_extension("import")
   end
 }
+```
 
 ## ⚙️ Configuration
 
@@ -62,4 +63,3 @@ require("telescope").setup({
 ```
 :Telescope import
 ```
-


### PR DESCRIPTION
- renamed "requires" to "dependencies" as per [lazy's migration guide](https://github.com/folke/lazy.nvim#-migration-guide).
- added missing backticks
- ran formatter to remove trailing spaces
