### PR TITLE
feat: user-defined custom_languages config take priority

### DIFF
--- a/lua/import/picker.lua
+++ b/lua/import/picker.lua
@@ -9,7 +9,7 @@ local find_imports = require("import.find_imports")
 local insert_line = require("import.insert_line")
 
 local function picker(opts)
-  local languages = utils.table_concat(default_languages, opts.custom_languages)
+  local languages = utils.table_concat(opts.custom_languages, default_languages)
 
   local imports = find_imports(languages)
 


### PR DESCRIPTION
Makes user-defined `custom_languages` config take priority over default language configs.

The function that picks which config to use simply chooses the first to match the filetype: https://github.com/piersolenski/telescope-import.nvim/blob/0270f1438c0ac91663146a73a213bfdc536a8cb5/lua/import/find_imports.lua#L14

fixes #17, because users can define their own language config which they could make fish-compatible by escaping the `$`