### PR TITLE
Fix Lua regex to allow `require"foo"` & `require("foo")`

### DIFF
--- a/lua/import/regex.lua
+++ b/lua/import/regex.lua
@@ -3,7 +3,7 @@ local regex = {
   go = [[^\t(\".*\")|^import (\".*\")]],
   java = [[^import\s+((static\s+)?[\w.]+\*?);\s*$]],
   javascript = [[^(?:import(?:[\"'\s]*([\w*{}\n, ]+)from\s*)?[\"'\s](.*?)[\"'\s].*)]],
-  lua = [[^local (\w+) = require\([\"'](.*?)[\"']\)]],
+  lua = [[^local (\w+) = require\(?[\"'](.*?)[\"']\)?]],
   php = [[^\s*use\s+([\w\\]+)(?:\s*;)?]],
   python = [[(?m)^(?:from[ ]+(\S+)[ ]+)?import[ ]+(\S+)[ ]*$]],
   shell = [[^(?:source\s+)]],


### PR DESCRIPTION
Closes #33 

![image](https://github.com/user-attachments/assets/c110d017-d482-4973-bf36-349d187b280e)
