### PR TITLE
Further adjust Lua regex to allow `require 'foo'`

### DIFF
--- a/lua/import/regex.lua
+++ b/lua/import/regex.lua
@@ -3,7 +3,7 @@ local regex = {
   go = [[^\t(\".*\")|^import (\".*\")]],
   java = [[^import\s+((static\s+)?[\w.]+\*?);\s*$]],
   javascript = [[^(?:import(?:[\"'\s]*([\w*{}\n, ]+)from\s*)?[\"'\s](.*?)[\"'\s].*)]],
-  lua = [[^local (\w+) = require\(?[\"'](.*?)[\"']\)?]],
+  lua = [[^local (\w+) = require\(?\s*[\"'](.*?)[\"']\s*\)?]],
   php = [[^\s*use\s+([\w\\]+)(?:\s*;)?]],
   python = [[(?m)^(?:from[ ]+(\S+)[ ]+)?import[ ]+(\S+)[ ]*$]],
   shell = [[^(?:source\s+)]],


### PR DESCRIPTION
When Stylua strips call parentheses, it leaves a space between the `require` and the argument, e.g. `require 'foo'`.