### PR TITLE
Allow multiple import selection using tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 An extension for [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim)
 that allows you to import modules faster based on what you've already imported in your project.
 
-Often we find ourselves importing the same modules over and over again in an existing project. Rather than typing out import statements from scratch or yanking them from other existing files, `telescope-import.nvim` searches your project for existing import statements giving you a faster way to add them to the current buffer. Import patterns are sorted by frequency, so your most used statements are usually just a few keystrokes away.
+Often we find ourselves importing the same modules over and over again in an existing project. Rather than typing out import statements from scratch or yanking them from other existing files, `telescope-import.nvim` searches your project for existing import statements giving you a faster way to add them to the current buffer. Import patterns are sorted by frequency, so your most used statements are usually just a few keystrokes away. You can select multiple items to import using tab.
 
 For languages that support auto importing through their LSP, `telescope-import` may still be of benefit by importing frequently used patterns of exports, rather than individually importing one at a time, or all at once, which can be inaccurate when there are multiple symbols with the same name in the project.
 
-https://github.com/piersolenski/telescope-import.nvim/assets/1285419/014753e3-ea7b-4bad-9f86-fb2566bf27c1
+https://github.com/user-attachments/assets/b5c2d7bd-ced7-44d1-abd2-d96de37a05e8
 
 ## 🤖 Supported languages
 - Bash
@@ -55,7 +55,7 @@ require("telescope").setup({
           -- The filetypes that ripgrep supports (find these via `rg --type-list`)
           extensions = { "js", "ts" },
           -- The Vim filetypes
-	   	filetypes = { "vue" },
+          filetypes = { "vue" },
           -- Optionally set a line other than 1
           insert_at_line = 2 ---@type function|number,
           -- The regex pattern for the import statement

--- a/doc/telescope-import.nvim.txt
+++ b/doc/telescope-import.nvim.txt
@@ -21,7 +21,8 @@ existing project. Rather than typing out import statements from scratch or
 yanking them from other existing files, `telescope-import.nvim` searches your
 project for existing import statements giving you a faster way to add them to
 the current buffer. Import patterns are sorted by frequency, so your most used
-statements are usually just a few keystrokes away.
+statements are usually just a few keystrokes away. You can select multiple
+items to import using tab.
 
 For languages that support auto importing through their LSP, `telescope-import`
 may still be of benefit by importing frequently used patterns of exports,
@@ -29,7 +30,7 @@ rather than individually importing one at a time, or all at once, which can be
 inaccurate when there are multiple symbols with the same name in the project.
 
 
-https://github.com/piersolenski/telescope-import.nvim/assets/1285419/014753e3-ea7b-4bad-9f86-fb2566bf27c1
+https://github.com/user-attachments/assets/b5c2d7bd-ced7-44d1-abd2-d96de37a05e8
 
 
 SUPPORTED LANGUAGES*telescope-import.nvim-telescope-import.nvim-supported-languages*
@@ -82,7 +83,7 @@ tweak it in the following ways:
               -- The filetypes that ripgrep supports (find these via `rg --type-list`)
               extensions = { "js", "ts" },
               -- The Vim filetypes
-            filetypes = { "vue" },
+              filetypes = { "vue" },
               -- Optionally set a line other than 1
               insert_at_line = 2 ---@type function|number,
               -- The regex pattern for the import statement

--- a/doc/telescope-import.nvim.txt
+++ b/doc/telescope-import.nvim.txt
@@ -1,4 +1,4 @@
-*telescope-import.nvim.txt*     For NVIM v0.8.0    Last change: 2024 August 27
+*telescope-import.nvim.txt*      For NVIM v0.8.0     Last change: 2025 June 11
 
 ==============================================================================
 Table of Contents                    *telescope-import.nvim-table-of-contents*

--- a/lua/telescope/_extensions/import.lua
+++ b/lua/telescope/_extensions/import.lua
@@ -1,5 +1,5 @@
 local has_telescope, telescope = pcall(require, "telescope")
-local picker = require("import.picker")
+local picker = require("import")
 local validate_config = require("import.validate_config")
 
 if not has_telescope then


### PR DESCRIPTION
Allows the user to pick multiple imports using the tab key, and then import them all in one go, rather than having to reopen Telescope multiple times.