### PR TITLE
Fix nushell string escaping

### DIFF
--- a/doc/telescope-import.nvim.txt
+++ b/doc/telescope-import.nvim.txt
@@ -1,4 +1,4 @@
-*telescope-import.nvim.txt*     For NVIM v0.8.0    Last change: 2025 August 15
+*telescope-import.nvim.txt*     For NVIM v0.10.0    Last change: 2025 August 15
 
 ==============================================================================
 Table of Contents                    *telescope-import.nvim-table-of-contents*

--- a/plugin/import.lua
+++ b/plugin/import.lua
@@ -1,5 +1,5 @@
-if vim.fn.has("nvim-0.7.0") == 0 then
-  vim.api.nvim_err_writeln("import.nvim requires at least nvim-0.7.0.1")
+if vim.fn.has("nvim-0.10.0") == 0 then
+  vim.api.nvim_err_writeln("import.nvim requires at least nvim-0.10.0")
   return
 end
 

--- a/tests/import/core/regex_spec.lua
+++ b/tests/import/core/regex_spec.lua
@@ -19,10 +19,22 @@ describe("Regex with rg", function()
       file:close()
     end
 
-    local flags = table.concat(constants.rg_flags, " ")
-    local find_command =
-      string.format("rg %s %s %s", flags, vim.fn.shellescape(regex[language]), test_file)
-    local result = vim.fn.systemlist(find_command)
+    -- Build ripgrep command as array of arguments
+    local args = {}
+    for _, flag in ipairs(constants.rg_flags) do
+      table.insert(args, flag)
+    end
+    table.insert(args, regex[language])
+    table.insert(args, test_file)
+
+    -- Execute ripgrep using vim.system()
+    local result_obj = vim.system({ "rg", unpack(args) }, { text = true }):wait()
+
+    -- Split stdout into lines
+    local result = {}
+    if result_obj.stdout and result_obj.stdout ~= "" then
+      result = vim.split(result_obj.stdout, "\n", { plain = true, trimempty = true })
+    end
 
     assert.are.same(expected_lines, result)
   end


### PR DESCRIPTION
The Nushell string escaping issue in https://github.com/piersolenski/import.nvim/issues/60 was caused by using vim.fn.systemlist() with manual string concatenation and shell escaping. 

This fix replaces all ripgrep invocations with the modern vim.system() API (note only available in Neovim 0.10.0+, yolooo), which passes arguments as arrays directly to the executable without shell interpretation. This eliminates all quoting and escaping concerns across all shells including Nushell, bash, zsh, and fish.